### PR TITLE
Feature/ameriflux met

### DIFF
--- a/config_files/model_config.yml
+++ b/config_files/model_config.yml
@@ -4,7 +4,9 @@ model_options:
   ###############################################################################
 
   # File for input met data
-  input_fname: "UMBS_flux_2011.csv"
+  input_fname: "FLX_US-UMB_FLUXNET2015_SUBSET_HH_2007-2017_beta-4.csv"
+  met_column_labels:
+    CO2_F_MDS: CO2_F
 
 # Start and end in the fetch2 example
   start_time: "2011-07-07 11:00:00" #begining of simulation #DOY 160

--- a/config_files/model_config_PM.yml
+++ b/config_files/model_config_PM.yml
@@ -3,7 +3,9 @@ model_options:
   ###########################
 
   # File for input met data
-  input_fname: "UMBS_flux_2011.csv"
+  input_fname: "FLX_US-UMB_FLUXNET2015_SUBSET_HH_2007-2017_beta-4.csv"
+  met_column_labels:
+    CO2_F_MDS: CO2_F
 
   # Start and end in the fetch2 example
   # start_time: "2011-06-09 00:00:00" #begining of simulation #DOY 160

--- a/config_files/opt_model_config.yml
+++ b/config_files/opt_model_config.yml
@@ -20,7 +20,9 @@ model_options:
   ###############################################################################
 
   # File for input met data
-  input_fname: "UMBS_flux_2011.csv"
+  input_fname: "FLX_US-UMB_FLUXNET2015_SUBSET_HH_2007-2017_beta-4.csv"
+  met_column_labels:
+    CO2_F_MDS: CO2_F
 
 # Start and end in the fetch2 example
   start_time: "2011-07-06 00:00:00" #begining of simulation #DOY 160

--- a/config_files/opt_umbs_M8.yml
+++ b/config_files/opt_umbs_M8.yml
@@ -20,7 +20,9 @@ model_options:
   ###############################################################################
 
   # File for input met data
-  input_fname: "UMBS_flux_2011.csv"
+  input_fname: "FLX_US-UMB_FLUXNET2015_SUBSET_HH_2007-2017_beta-4.csv"
+  met_column_labels:
+    CO2_F_MDS: CO2_F
 
 # Start and end in the fetch2 example
   start_time: "2011-07-06 00:00:00" #begining of simulation #DOY 160

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,17 @@
 Change log
 ##########
 
+6-7-22:
+-------
+- Updates to input file format and options
+
+  - Ameriflux standard variable names and units are used for all variables by default.
+
+    .. important::
+        VPD must now be given in units of hPa (to match the units used by AmeriFlux), rather than kPa
+  - Users can use column headers other than the default variable names, as long as the mapping of these column headers
+    to the default variable names is specified in the configuration file.
+
 5-31-22:
 --------
 - Added soil moisture at bottom boundary as a parameter in the model configuration

--- a/docs/user_guide/input_files.rst
+++ b/docs/user_guide/input_files.rst
@@ -5,41 +5,45 @@ Prepare input files for the model
 Meteorological data
 ===================
 
-Prepare a .csv file with the required variables. See ``UMBS_flux_2011.csv`` in the data folder for an example,
-although your file doesn't need to have all of the variables that are included in this file.
+Prepare a .csv file with the required variables. See ``FLX_US-UMB_FLUXNET2015_SUBSET_HH_2007-2017_beta-4.csv`` in the
+data folder for an example, although your file doesn't need to have all of the variables included in this file.
+
+By default, the column headers in the input data are assumed to match the Ameriflux standard variable names. If
+different column headers are used, the mapping of the column headers to the required variables but be specified in the
+config file.
 
 The meteorological variables that are required depend on whether you are using PM or NHL transpiration.
 
-.. note::
-    - The column headers in the .csv file must match the names used below. Most of these names/units
-      match those used by AmeriFlux, except for Timestamp and VPD_kPa
-    - The data should be gap-filled.
 
 **If using the PM transpiration scheme, the file must include:**
 
-- *Timestamp*
+- *TIMESTAMP_START*: Timestamp (in local standard time) using either Ameriflux format (YYYYMMDDHHMM) or standard format
+  (YYYY-MM-DD HH:MM)
 - *P_F*: Precipitation [mm]
 - *TA_F*: Air temperature [deg C]
 - *SW_IN_F*: Incoming shortwave radiation [W m-2]
-- *VPD_kPa*: Vapor pressure deficit [kPa]
+- *VPD_F*: Vapor pressure deficit [hPa]
 
 
 **If using the NHL transpiration scheme, the file must include:**
 
-- *Timestamp*
+- *TIMESTAMP_START*: Timestamp (in local standard time) using either Ameriflux format (YYYYMMDDHHMM) or standard format
+  (YYYY-MM-DD HH:MM)
 - *P_F*: Precipitation [mm]
 - *TA_F*: Air temperature [deg C]
 - *SW_IN_F*: Incoming shortwave radiation [W m-2]
-- *VPD_kPa*: Vapor pressure deficit [kPa]
+- *VPD_F*: Vapor pressure deficit [hPa]
 - *WS_F*: Wind speed above the canopy [m s-1]
 - *USTAR*: Friction velocity [m s-1]
 - *PPFD_IN*: Incoming photosynthetic photon flux density (PAR) [µmolPhoton m-2 s-1]
 - *CO2_F*: CO2 concentration [µmolCO2 mol-1]
-- *RH*: Relative humidity [%]
 - *PA_F*: Atmospheric pressure [kPa]
 
-.. todo::
-    A future version will allow the user to specify different column names for the required met data
+.. important::
+    - If different column headers are used, this must be specified in the configuration file. See
+      :ref:`Model Configuration`
+    - The data should be gap-filled.
+
 
 Leaf area density profile
 =========================

--- a/fetch3/initial_conditions.py
+++ b/fetch3/initial_conditions.py
@@ -46,8 +46,8 @@ def calc_potential_vangenuchten(theta, theta_r, theta_s, alpha, m, n, rho, g):
 
     """
 
-    effective_saturation = ((theta - theta_r) / (theta_s - theta_r))
-    water_potential_m = - ((((1 / effective_saturation) ** (1 / m) - 1) ** (1 / n)) / alpha)
+    effective_saturation = (theta - theta_r) / (theta_s - theta_r)
+    water_potential_m = -((((1 / effective_saturation) ** (1 / m) - 1) ** (1 / n)) / alpha)
     water_potential_Pa = water_potential_m * rho * g
 
     return water_potential_Pa  # [Pa]
@@ -76,13 +76,32 @@ def initial_conditions(cfg, q_rain, zind):
     """
 
     # soil
-    H_initial_soil = np.piecewise(zind.z_soil,
-                                  [zind.z_soil <= cfg.clay_d, zind.z_soil > cfg.clay_d],
-                                  [calc_potential_vangenuchten(cfg.initial_swc_clay, cfg.theta_R1, cfg.theta_S1,
-                                                               cfg.alpha_1, cfg.m_1, cfg.n_1, cfg.Rho, cfg.g),
-                                   calc_potential_vangenuchten(cfg.initial_swc_sand, cfg.theta_R2, cfg.theta_S2,
-                                                               cfg.alpha_2, cfg.m_2, cfg.n_2, cfg.Rho, cfg.g)]
-                                  )
+    H_initial_soil = np.piecewise(
+        zind.z_soil,
+        [zind.z_soil <= cfg.clay_d, zind.z_soil > cfg.clay_d],
+        [
+            calc_potential_vangenuchten(
+                cfg.initial_swc_clay,
+                cfg.theta_R1,
+                cfg.theta_S1,
+                cfg.alpha_1,
+                cfg.m_1,
+                cfg.n_1,
+                cfg.Rho,
+                cfg.g,
+            ),
+            calc_potential_vangenuchten(
+                cfg.initial_swc_sand,
+                cfg.theta_R2,
+                cfg.theta_S2,
+                cfg.alpha_2,
+                cfg.m_2,
+                cfg.n_2,
+                cfg.Rho,
+                cfg.g,
+            ),
+        ],
+    )
 
     # roots
 
@@ -98,13 +117,22 @@ def initial_conditions(cfg, q_rain, zind):
     H_initial = np.concatenate((H_initial_soil, H_initial_root, H_initial_xylem))
 
     # calculate water potential for the bottom boundary condition
-    Head_bottom_H = np.full(len(q_rain),
-                            calc_potential_vangenuchten(cfg.soil_moisture_bottom_boundary, cfg.theta_R1, cfg.theta_S1,
-                                                        cfg.alpha_1, cfg.m_1, cfg.n_1, cfg.Rho, cfg.g))
+    Head_bottom_H = np.full(
+        len(q_rain),
+        calc_potential_vangenuchten(
+            cfg.soil_moisture_bottom_boundary,
+            cfg.theta_R1,
+            cfg.theta_S1,
+            cfg.alpha_1,
+            cfg.m_1,
+            cfg.n_1,
+            cfg.Rho,
+            cfg.g,
+        ),
+    )
 
     # set bottom boundary for initial condition
     if cfg.BottomBC == 0:
         H_initial[0] = Head_bottom_H[0]
 
     return H_initial, Head_bottom_H
-

--- a/fetch3/met_data.py
+++ b/fetch3/met_data.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from fetch3.utils import interpolate_2d
 
-filepath = '/Users/jmissik/Desktop/repos/fetch3_nhl/data/FLX_US-UMB_FLUXNET2015_SUBSET_HH_2007-2017_beta-4.csv'
+filepath = "/Users/jmissik/Desktop/repos/fetch3_nhl/data/FLX_US-UMB_FLUXNET2015_SUBSET_HH_2007-2017_beta-4.csv"
 
 
 def import_ameriflux_data(filein):
@@ -29,7 +29,7 @@ def import_ameriflux_data(filein):
         Flux data
     """
 
-    df = pd.read_csv(filein, parse_dates=['TIMESTAMP_START', 'TIMESTAMP_END'], na_values=['-9999'])
+    df = pd.read_csv(filein, parse_dates=["TIMESTAMP_START", "TIMESTAMP_END"], na_values=["-9999"])
 
     return df
 
@@ -37,19 +37,34 @@ def import_ameriflux_data(filein):
 def prepare_ameriflux_data(filein, cfg):
 
     df = import_ameriflux_data(filein)
-    df = df.rename(columns={'TIMESTAMP_START': 'Timestamp'})
+    df = df.rename(columns={"TIMESTAMP_START": "Timestamp"})
 
     # Rename
     df = df.rename(columns=cfg.met_column_labels)
 
     # Add VPD in kPa. VPD_F is in hPa
-    df['VPD_F_kPa'] = df.VPD_F / 10
+    df["VPD_F_kPa"] = df.VPD_F / 10
 
     # Keep only variables needed
-    df = df[['Timestamp', 'TA_F', 'VPD_F_kPa', 'P_F', 'SW_IN_F', 'WS_F', 'USTAR', 'PPFD_IN', 'CO2_F', 'PA_F']]
+    df = df[
+        [
+            "Timestamp",
+            "TA_F",
+            "VPD_F_kPa",
+            "P_F",
+            "SW_IN_F",
+            "WS_F",
+            "USTAR",
+            "PPFD_IN",
+            "CO2_F",
+            "PA_F",
+        ]
+    ]
 
     # Select data for length of run
-    df = df[(df.Timestamp >= cfg.start_time) & (df.Timestamp <= cfg.end_time)].reset_index(drop=True)
+    df = df[(df.Timestamp >= cfg.start_time) & (df.Timestamp <= cfg.end_time)].reset_index(
+        drop=True
+    )
 
     return df
 

--- a/fetch3/met_data.py
+++ b/fetch3/met_data.py
@@ -45,9 +45,10 @@ def prepare_ameriflux_data(filein, cfg):
     # Add VPD in kPa. VPD_F is in hPa
     df["VPD_F_kPa"] = df.VPD_F / 10
 
-    # Keep only variables needed
-    df = df[
-        [
+    if cfg.transpiration_scheme == 0:
+        varlist = ["Timestamp", "TA_F", "VPD_F_kPa", "P_F", "SW_IN_F"]
+    elif cfg.transpiration_scheme == 1:
+        varlist = [
             "Timestamp",
             "TA_F",
             "VPD_F_kPa",
@@ -59,7 +60,9 @@ def prepare_ameriflux_data(filein, cfg):
             "CO2_F",
             "PA_F",
         ]
-    ]
+
+    # Keep only variables needed
+    df = df[varlist]
 
     # Select data for length of run
     df = df[(df.Timestamp >= cfg.start_time) & (df.Timestamp <= cfg.end_time)].reset_index(

--- a/fetch3/met_data.py
+++ b/fetch3/met_data.py
@@ -12,6 +12,47 @@ import pandas as pd
 
 from fetch3.utils import interpolate_2d
 
+filepath = '/Users/jmissik/Desktop/repos/fetch3_nhl/data/FLX_US-UMB_FLUXNET2015_SUBSET_HH_2007-2017_beta-4.csv'
+
+
+def import_ameriflux_data(filein):
+    """
+    Imports AmeriFlux data (in ONEFLUX format) to a DataFrame.
+    Parameters
+    ----------
+    filein : str
+        Filepath to data
+
+    Returns
+    -------
+    df: pd.DataFrame
+        Flux data
+    """
+
+    df = pd.read_csv(filein, parse_dates=['TIMESTAMP_START', 'TIMESTAMP_END'], na_values=['-9999'])
+
+    return df
+
+
+def prepare_ameriflux_data(filein, cfg):
+
+    df = import_ameriflux_data(filein)
+    df = df.rename(columns={'TIMESTAMP_START': 'Timestamp'})
+
+    # Rename
+    df = df.rename(columns=cfg.met_column_labels)
+
+    # Add VPD in kPa. VPD_F is in hPa
+    df['VPD_F_kPa'] = df.VPD_F / 10
+
+    # Keep only variables needed
+    df = df[['Timestamp', 'TA_F', 'VPD_F_kPa', 'P_F', 'SW_IN_F', 'WS_F', 'USTAR', 'PPFD_IN', 'CO2_F', 'PA_F']]
+
+    # Select data for length of run
+    df = df[(df.Timestamp >= cfg.start_time) & (df.Timestamp <= cfg.end_time)].reset_index(drop=True)
+
+    return df
+
 
 # Helper functions
 def calc_model_time_grid(df, cfg):
@@ -71,10 +112,8 @@ def prepare_met_data(cfg, data_dir, z_upper):
     end_time = pd.to_datetime(cfg.end_time)
 
     # read input data
-    df = pd.read_csv(data_path, parse_dates=[0])
+    df = prepare_ameriflux_data(data_path, cfg)
 
-    # Select data for length of run
-    df = df[(df.Timestamp >= start_time) & (df.Timestamp <= end_time)]
     df = df.set_index("Timestamp")
 
     tmax, t_data, nt_data = calc_model_time_grid(df, cfg)
@@ -84,7 +123,7 @@ def prepare_met_data(cfg, data_dir, z_upper):
 
     Ta_C = df["TA_F"]
     SW_in = df["SW_IN_F"]
-    VPD = df["VPD_kPa"]
+    VPD = df["VPD_F_kPa"]
 
     # temperature
     Ta = Ta_C + 273.15  # converting temperature from degree Celsius to Kelvin

--- a/fetch3/model_config.py
+++ b/fetch3/model_config.py
@@ -26,6 +26,19 @@ See ``model_config.yml`` for an example.
 Model options
 -------------
 * **input_fname** (str): File for input met data
+* **met_column_labels** (dict): Dictionary specifying the mapping of the column headers in your input file to the
+  required input variables. This is needed if your column headers differ from the default variable names. See
+  :ref:`Prepare input files for the model` for a list of the default variable names. Each element in the dictionary
+  should be formatted as <your column header>: <standard variable name>, for example::
+
+    met_column_labels:
+      CO2_F_MDS: CO2_F
+
+  Alternately, the dictionary can also be formatted as::
+
+    met_column_labels: {'CO2_F_MDS': 'CO2_F'}
+
+
 * **start_time** (str): ["YYYY-MM-DD HH:MM:SS"] Begining of simulation
 * **end_time** (str): ["YYYY-MM-DD HH:MM:SS"] End of simulation
 

--- a/fetch3/model_config.py
+++ b/fetch3/model_config.py
@@ -414,6 +414,8 @@ class ConfigParams:
     mean_crown_area_sp: float
     sum_LAI_plot: float
 
+    met_column_labels: dict = None
+
     #########################################################################3
     # NHL PARAMETERS
     ###########################################################################

--- a/fetch3/nhl_transpiration/NHL_functions.py
+++ b/fetch3/nhl_transpiration/NHL_functions.py
@@ -737,7 +737,6 @@ def calc_NHL(cfg, met_data, LADnorm_df, timestep):
     ustar = met_data.USTAR[timestep]
     PAR = met_data.PPFD_IN[timestep]
     Ca = met_data.CO2_F[timestep]
-    RH = met_data.RH[timestep]
     Tair = met_data.TA_F[timestep]
     Press = met_data.PA_F[timestep]
     doy = met_data.Timestamp.iloc[timestep].dayofyear
@@ -746,8 +745,7 @@ def calc_NHL(cfg, met_data, LADnorm_df, timestep):
     LADnorm = LADnorm_df[cfg.species]
     z_h_LADnorm = LADnorm_df.z_h
 
-    # Calculate VPD
-    VPD = calc_vpd_kPa(RH, Tair=Tair)
+    VPD = met_data.VPD_F_kPa[timestep]
 
     # Set up vertical grid
     zmin = 0

--- a/fetch3/nhl_transpiration/main.py
+++ b/fetch3/nhl_transpiration/main.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 
 from fetch3.nhl_transpiration.NHL_functions import *
+from fetch3.met_data import prepare_ameriflux_data
 
 
 def main(cfg, output_dir, data_dir):
@@ -32,13 +33,8 @@ def main(cfg, output_dir, data_dir):
     ###################################################
 
     # Read in LAD and met data
-    met_data = pd.read_csv(data_dir / cfg.input_fname, parse_dates=[0])
+    met_data = prepare_ameriflux_data(data_dir / cfg.input_fname, cfg)
     LADnorm_df = pd.read_csv(data_dir / cfg.LAD_norm)
-
-    met_data = met_data[
-        (met_data.Timestamp >= pd.to_datetime(cfg.start_time))
-        & (met_data.Timestamp <= pd.to_datetime(cfg.end_time))
-    ].reset_index(drop=True)
 
     logger.info("Calculating NHL...")
 

--- a/fetch3/nhl_transpiration/main.py
+++ b/fetch3/nhl_transpiration/main.py
@@ -19,8 +19,8 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from fetch3.nhl_transpiration.NHL_functions import *
 from fetch3.met_data import prepare_ameriflux_data
+from fetch3.nhl_transpiration.NHL_functions import *
 
 
 def main(cfg, output_dir, data_dir):


### PR DESCRIPTION
- Updates to input file format and options

  - Ameriflux standard variable names and units are used for all variables by default. Important: VPD now must be given in     units of hPa (to match Ameriflux format), rather than kPa
  - Users can use column headers other than the default variable names, as long as the mapping of these column headers to the default variable names is specified in the configuration file.
